### PR TITLE
fix(csuthesis.cls): update `lstlisting` to use monospace font

### DIFF
--- a/csuthesis.cls
+++ b/csuthesis.cls
@@ -289,6 +289,7 @@
 % 设置代码环境
 \RequirePackage{listings}
 \lstset{
+  basicstyle=\ttfamily,
   breaklines,
   columns=fixed,       
   numbers=none,                                        % 在左侧显示行号


### PR DESCRIPTION
Switch to monospace font in `lstlisting` environment by setting `basicstyle` to `\ttfamily`